### PR TITLE
Use appropriate method to calculate salt

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -60,7 +60,7 @@ namespace GMSAPasswordReader
                 return;
             }
             
-            var salt = $"{domainName.ToUpper()}{userName}";
+            var salt = $"{domainName.ToUpper()}host{userName.Remove(userName.Length -1,1).ToLower()}.{domainName.ToLower()}";
 
             if (!string.IsNullOrEmpty(userName) && !string.IsNullOrEmpty(domainName))
             {


### PR DESCRIPTION
GMSAs are considered as machine accounts. Therefore the salt must be generated according to the following scheme: uppercase realm + "host" + lowercase hostname without the trailing '$' + "." + lowercase realm 

With the current method, the calculated AES keys are invalid.